### PR TITLE
No memory leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     </developers>
  
     <properties>
-        <metrics.version>2.1.1</metrics.version>
+        <metrics.version>2.1.2</metrics.version>
         <slf4j.version>1.6.4</slf4j.version>
     </properties>
 


### PR DESCRIPTION
Creating the script engine on each execution resulting in a memory leak. This change will cause the script engine to be reused on each run.
